### PR TITLE
Replaced kebab-case for path with a working one

### DIFF
--- a/apisyouwonthate.yml
+++ b/apisyouwonthate.yml
@@ -39,7 +39,7 @@ rules:
     then:
       function: pattern
       functionOptions:
-        match: "^(\/[a-z0-9-.]+|\/{[a-zA-Z0-9_]+})+$"
+        match: "^(\/|[a-z0-9-.]+|{[a-zA-Z0-9_]+})+$"
 
   no-http-basic:
     description: "Consider a more secure alternative to HTTP Basic."

--- a/apisyouwonthate.yml
+++ b/apisyouwonthate.yml
@@ -31,18 +31,15 @@ rules:
       field: get
       function: truthy
 
-  # paths-kebab-case:
-  #   description: Should paths be kebab-case.
-  #   message: '{{property}} should be kebab-case (lower case and separated with hyphens)'
-  #   severity: warn
-  #   given: $.paths[*]~
-  #   then:
-  #     function: casing
-  #     functionOptions:
-  #       type: "kebab"
-  #       separator: 
-  #         char: /
-  #         allowLeading: true
+  paths-kebab-case:
+    description: Should paths be kebab-case.
+    message: '{{property}} should be kebab-case (lower case and separated with hyphens)'
+    severity: warn
+    given: $.paths[*]~
+    then:
+      function: pattern
+      functionOptions:
+        match: "^(\/[a-z0-9-.]+|\/{[a-zA-Z0-9_]+})+$"
 
   no-http-basic:
     description: "Consider a more secure alternative to HTTP Basic."


### PR DESCRIPTION
As stated here https://github.com/stoplightio/spectral/issues/1327 the best way to check kebab-case for path is using `pattern`