### PR TITLE
Fix syntax on get no body for formats

### DIFF
--- a/apisyouwonthate.yml
+++ b/apisyouwonthate.yml
@@ -89,7 +89,7 @@ rules:
   request-GET-no-body-oas2:
     description: A `GET` request MUST NOT accept a `body` parameter
     severity: error
-    format: [oas2]
+    formats: [oas2]
     given: $.paths..get.parameters..in
     then:
       function: pattern
@@ -100,7 +100,7 @@ rules:
   request-GET-no-body-oas3:
     description: A `GET` request MUST NOT accept a request body
     severity: error
-    format: [oas3]
+    formats: [oas3]
     given: $.paths..get.requestBody
     then:
       function: undefined


### PR DESCRIPTION
Current master branch fails to run with the following error (spectral cli 6.1.0, works fine with 5.7.1):
```
Error at #/rules/request-GET-no-body-oas2: must NOT have additional properties
Error at #/rules/request-GET-no-body-oas3: must NOT have additional properties
```

`format` should be `formats`.
https://meta.stoplight.io/docs/spectral/ZG9jOjYyMDc0NA-rulesets#formats